### PR TITLE
Update Humpback component docs for HTTP/HTTPS defaults

### DIFF
--- a/docs/run-humpback-components.md
+++ b/docs/run-humpback-components.md
@@ -25,10 +25,10 @@ By default, Humpback will expose the UI over port `8100` and expose a API server
 Humpback has now been installed. you can log into your Humpback instance by opening a web browser and going to:
 
 ```
-https://localhost:8100
+http://localhost:8100
 ```
 
-Both the web site and API site use HTTPS for communication by default. Humpback has an internal self-signed certificate management system. If your web site is behind a reverse proxy where HTTPS certificates are managed, you can disable HTTPS communication for the web site by setting the environment variable `SITE_CERT_ENABLED=false`. However, for security reasons, HTTPS communication between the API site and the agent cannot be disabled. That said, you don’t need to worry about this part, as Humpback handles certificate management for you.
+Website use HTTP and API site use HTTPS for communication by default. Humpback has an internal self-signed certificate management system. You can enable HTTPS communication for the web site by setting the environment variable `SITE_CERT_ENABLED=true`. However, for security reasons, HTTPS communication between the API site and the agent cannot be disabled. That said, you don’t need to worry about this part, as Humpback handles certificate management for you.
 
 You can use the account initialized by the system to log in. Both the username and the password are `humpback`. 
 
@@ -45,7 +45,6 @@ docker run -d \
   --privileged \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /var/lib/docker:/var/lib/docker \
-  -e HUMPBACK_AGENT_API_BIND=0.0.0.0:8018 \
   -e HUMPBACK_SERVER_HOST={server-address}:8101 \
   -e HUMPBACK_VOLUMES_ROOT_DIRECTORY=/var/lib/docker \
   humpbacks/humpback-agent

--- a/docs/zh-cn/run-humpback-components.md
+++ b/docs/zh-cn/run-humpback-components.md
@@ -13,8 +13,7 @@ Humpback 由两个核心组件构成：Humpback 和 Humpback Agent。这两个�
 ```bash
 docker run -d \
   --name humpback \
-  -p 8100:8100 \
-  -p 8101:8101 \
+  --net=host \
   --restart=always \
   -v humpback_data:/workspace/data \
   -v humpback_certs:/workspace/certs \
@@ -26,10 +25,10 @@ Humpback默认会监听两个端口，`8100`端口是web站点，`8101`是API服
 命令运行成功后，你可以通过打开下面的站点检查Humpback是否启动成功。
 
 ```
-https://localhost:8100
+http://localhost:8100
 ```
 
-Web站点和API站点默认都使用https进行通信。Humpback内部有一套自签名证书的管理体系。如果你的web站点前面还有反向代理，并且https证书在上面进行管理，那么你可以通过环境变量`SITE_CERT_ENABLED=false`关闭web站点的https通信。但是API站点和agent的通信出于安全考虑是不能关闭https通信的，不过你也无需操心这个部分，因为Humpback会为你做好证书的管理。
+Web站点默认使用http通信，但是API站点默认使用https进行通信。Humpback内部有一套自签名证书的管理体系。你可以通过环境变量`SITE_CERT_ENABLED=true`启用web站点的https通信。但是API站点和agent的通信出于安全考虑是不能关闭https通信的，不过你也无需操心这个部分，因为Humpback会为你做好证书的管理。
 
 你可以使用系统初始化的用户登录，用户名和密码都是 `humpback`。
 
@@ -48,7 +47,6 @@ docker run -d \
   --privileged \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /var/lib/docker:/var/lib/docker \
-  -e HUMPBACK_AGENT_API_BIND=0.0.0.0:8018 \
   -e HUMPBACK_SERVER_HOST={server-address}:8101 \
   -e HUMPBACK_VOLUMES_ROOT_DIRECTORY=/var/lib/docker \
   humpbacks/humpback-agent


### PR DESCRIPTION
Clarified that the web site uses HTTP by default and the API site uses HTTPS by default in both English and Chinese documentation. Updated instructions for enabling HTTPS on the web site and removed unnecessary environment variable from agent run command.